### PR TITLE
Solve deprecation notes related to NPM publish scripts

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -9,6 +9,6 @@
   },
   "confirm": true,
   "publishTag": "latest --access public",
-  "prePublishScript": "npm test",
+  "prePublishScript": false,
   "postPublishScript": false
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "karma": "karma start --single-run",
     "autoformat": "prettier --config .prettierrc --write {src,test}/**/*.ts",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "clean-up": "rm -rf coverage && rm -rf lib",
-    "prepublish": "tsc -d && publish-please guard",
-    "publish-please": "npm run autoformat && npm run clean-up && publish-please"
+    "clean-up": "rm -rf .nyc_output && rm -rf coverage && rm -rf lib",
+    "prepare": "npm run clean-up && tsc -d",
+    "prepublishOnly": "publish-please guard",
+    "publish-please": "npm run autoformat && npm run clean-up && npm run test && publish-please"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
Remove deprecation warning messages related to **npm publish** scripts:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```