### PR TITLE
Event class reads bubbles parameter passed through constructor

### DIFF
--- a/src/robotlegs/bender/events/impl/Event.ts
+++ b/src/robotlegs/bender/events/impl/Event.ts
@@ -4,14 +4,14 @@ export class Event implements IEvent {
     public type: string;
     public defaultPrevented: boolean;
     public bubbles: boolean;
+    public detail: any;
     public target: any;
     public currentTarget: any;
-    public detail: any;
 
     constructor(type: string, eventInit: IEventInit = { bubbles: false }) {
         this.type = type;
-        this.bubbles = false;
         this.defaultPrevented = false;
+        this.bubbles = eventInit.bubbles;
         this.detail = eventInit.detail;
     }
 

--- a/test/robotlegs/bender/events/impl/event.test.ts
+++ b/test/robotlegs/bender/events/impl/event.test.ts
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../entry";
+
+import { assert } from "chai";
+
+import { Event } from "../../../../../src/";
+
+describe("Event", () => {
+    it("event_only_with_type_is_initialized", () => {
+        let event: Event = new Event("added");
+        assert.equal(event.type, "added");
+        assert.isFalse(event.defaultPrevented);
+        assert.isFalse(event.bubbles);
+        assert.isUndefined(event.detail);
+    });
+
+    it("event_with_type_and_bubbles_is_initialized", () => {
+        let event: Event = new Event("added", { bubbles: true });
+        assert.equal(event.type, "added");
+        assert.isFalse(event.defaultPrevented);
+        assert.isTrue(event.bubbles);
+        assert.isUndefined(event.detail);
+    });
+
+    it("event_with_type_and_bubbles_and_detail_is_initialized", () => {
+        let detail: any = {};
+        let event: Event = new Event("added", { bubbles: true, detail });
+        assert.equal(event.type, "added");
+        assert.isFalse(event.defaultPrevented);
+        assert.isTrue(event.bubbles);
+        assert.equal(event.detail, detail);
+    });
+
+    it("preventDefault_is_called", () => {
+        let event: Event = new Event("added");
+        event.preventDefault();
+        assert.isTrue(event.defaultPrevented);
+    });
+
+    it("stopPropagation_is_called", () => {
+        let event: Event = new Event("added", { bubbles: true });
+        event.stopPropagation();
+        assert.isFalse(event.bubbles);
+    });
+});


### PR DESCRIPTION
**Event** class is not reading the **bubbles** parameter passed through constructor. This PR solves this:

```typescript
    constructor(type: string, eventInit: IEventInit = { bubbles: false }) {
        this.type = type;
        this.defaultPrevented = false;
        this.bubbles = eventInit.bubbles;
        this.detail = eventInit.detail;
    }
```

Closes #20