### PR TITLE
Update inversify to the latest version 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS#readme",
   "dependencies": {
-    "inversify": "^4.3.0"
+    "inversify": "^4.4.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.17",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "inversify": "^4.4.0"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.17",
+    "@types/bluebird": "^3.5.18",
     "@types/chai": "^4.0.4",
     "@types/mocha": "^2.2.44",
     "@types/sinon": "^2.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,11 +1672,11 @@ extglob@^0.3.1:
     is-extglob "^1.0.0"
 
 extract-zip@~1.6.5:
-  version "1.6.5"
-  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
+  version "1.6.6"
+  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
   dependencies:
     concat-stream "1.6.0"
-    debug "2.2.0"
+    debug "2.6.9"
     mkdirp "0.5.0"
     yauzl "2.4.1"
 
@@ -2908,8 +2908,8 @@ jsprim@^1.2.2:
     verror "1.10.0"
 
 just-extend@^1.1.26:
-  version "1.1.26"
-  resolved "https://registry.npmjs.org/just-extend/-/just-extend-1.1.26.tgz#dba4ad2786d319f1d10afab106e004b5a0851ac2"
+  version "1.1.27"
+  resolved "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
 
 karma-chai-sinon@^0.1.5:
   version "0.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,9 +2529,9 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/inversify/-/inversify-4.3.0.tgz#d2ecd2ae18340e7f1ab5148a3e44b87080391366"
+inversify@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/inversify/-/inversify-4.4.0.tgz#6bf7a6fb18fc381b6b9c954e5016b8b830da4feb"
 
 invert-kv@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@types/bluebird@^3.5.17":
-  version "3.5.17"
-  resolved "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.17.tgz#f9eee76920e7aded0f665ee7658c058407bd12ff"
+"@types/bluebird@^3.5.18":
+  version "3.5.18"
+  resolved "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz#6a60435d4663e290f3709898a4f75014f279c4d6"
 
 "@types/chai@^4.0.4":
   version "4.0.4"


### PR DESCRIPTION
## Version **4.4.0** of [inversify](https://github.com/inversify/InversifyJS) was just published.

<table>
  <tr>
    <th align=left>
      Dependency
    </td>
    <td>
      inversify
    </td>
  </tr>
  <tr>
    <th align=left>
      Current Version
    </td>
    <td>
      4.3.0
    </td>
  </tr>
  <tr>
    <th align=left>
      Type
    </td>
    <td>
      dependency
    </td>
  </tr>
</table>