### PR TITLE
Update inversify to the latest version 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ts-node": "^3.3.0",
     "tslint": "^5.8.0",
     "tslint-config-prettier": "^1.6.0",
-    "typescript": "^2.5.3",
+    "typescript": "^2.6.1",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS#readme",
   "dependencies": {
-    "inversify": "^4.4.0"
+    "inversify": "^4.5.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.18",

--- a/test/robotlegs/bender/framework/impl/robotlegsInjector.test.ts
+++ b/test/robotlegs/bender/framework/impl/robotlegsInjector.test.ts
@@ -29,12 +29,12 @@ describe("RobotlegsInjector", () => {
     it("parent get set", () => {
         childInjector = new RobotlegsInjector();
         childInjector.parent = parentInjector;
-        assert.equal(parentInjector, childInjector.parent);
+        assert.equal(parentInjector, <RobotlegsInjector>childInjector.parent);
     });
 
     it("createChild remembers parent", () => {
         childInjector = <RobotlegsInjector>parentInjector.createChild();
-        assert.equal(parentInjector, childInjector.parent);
+        assert.equal(parentInjector, <RobotlegsInjector>childInjector.parent);
     });
 
     it("isBound check if a identifier is mapped", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,8 +239,8 @@ asap@^2.0.0:
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
-  version "4.9.1"
-  resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz#48ba240b45a9280e94748990ba597d216617fd40"
+  version "4.9.2"
+  resolved "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz#8117ef4f7ed87cd8f89044b5bff97ac243a16c9a"
   dependencies:
     bn.js "^4.0.0"
     inherits "^2.0.1"
@@ -1204,6 +1204,10 @@ detect-indent@^4.0.0:
   resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
     repeating "^2.0.0"
+
+detect-libc@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz#71ad5d204bf17a6a6ca8f450c61454066ef461e1"
 
 detect-node@^2.0.3:
   version "2.0.3"
@@ -3572,9 +3576,10 @@ node-libs-browser@^2.0.0:
     vm-browserify "0.0.4"
 
 node-pre-gyp@^0.6.36:
-  version "0.6.38"
-  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz#e92a20f83416415bb4086f6d1fb78b3da73d113d"
+  version "0.6.39"
+  resolved "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
+    detect-libc "^1.0.2"
     hawk "3.1.3"
     mkdirp "^0.5.1"
     nopt "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,9 +2529,9 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/inversify/-/inversify-4.4.0.tgz#6bf7a6fb18fc381b6b9c954e5016b8b830da4feb"
+inversify@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/inversify/-/inversify-4.5.0.tgz#1a575ddf1db216ed3292d9b0f70f497de275874e"
 
 invert-kv@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5252,9 +5252,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"


### PR DESCRIPTION
## Version **<a href="https://github.com/inversify/InversifyJS/releases/tag/4.5.0">4.5.0</a>** of [inversify](https://github.com/inversify/InversifyJS) was just published.

<table>
  <tr>
    <th align=left>
      Dependency
    </td>
    <td>
      inversify
    </td>
  </tr>
  <tr>
    <th align=left>
      Current Version
    </td>
    <td>
      4.4.0
    </td>
  </tr>
  <tr>
    <th align=left>
      Type
    </td>
    <td>
      dependency
    </td>
  </tr>
</table>