### PR TITLE
Update NPM Ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 /.vscode
 /coverage
 /docs
+/media
 /lib/test
 /not-ported-extensions
 /src

--- a/.npmignore
+++ b/.npmignore
@@ -10,7 +10,6 @@
 /test
 /transpiled-code
 /typings
-CHANGELOG.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 ISSUE_TEMPLATE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### v0.1.1
 
+- Update .npmignore (see #31).
+
 - Update dev dependencies to latest version.
 
 ### [v0.1.0](https://github.com/RobotlegsJS/RobotlegsJS/releases/tag/0.1.0) - 2017-11-10


### PR DESCRIPTION
- Ignore logo when publishing package to NPM.
- Remove **CHANGELOG.md** file from **.npmignore**, since it will never be ignored by NPM.

> The following paths and files are never ignored, so adding them to .npmignore is pointless:
> * package.json
> * README (and its variants)
> * CHANGELOG (and its variants)
> * LICENSE / LICENCE

[Keeping files out of your package](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)