### PR TITLE
Strict Type Checking for TypeMatcher class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
 
 ## Robotlegs-Core 0.1.0
 
-### v0.1.1
+### [v0.1.1](https://github.com/RobotlegsJS/RobotlegsJS/releases/tag/0.1.1) - 2017-11-13
+
+- Strict Type Checking for TypeMatcher class (see #32).
 
 - Update .npmignore (see #31).
 

--- a/src/robotlegs/bender/extensions/matching/TypeMatcher.ts
+++ b/src/robotlegs/bender/extensions/matching/TypeMatcher.ts
@@ -35,24 +35,45 @@ export class TypeMatcher implements ITypeMatcher, ITypeMatcherFactory {
     /**
      * All types that an item must extend or implement
      */
-    public allOf(...types: any[]): TypeMatcher {
-        this.pushAddedTypesTo(types, this._allOfTypes);
+    public allOf(
+        type: IType<any> | Array<IType<any>>,
+        ...types: Array<IType<any>>
+    ): TypeMatcher {
+        if (type instanceof Array) {
+            this.pushAddedTypesTo(type.concat(types), this._allOfTypes);
+        } else {
+            this.pushAddedTypesTo([type].concat(types), this._allOfTypes);
+        }
         return this;
     }
 
     /**
      * Any types that an item must extend or implement
      */
-    public anyOf(...types: any[]): TypeMatcher {
-        this.pushAddedTypesTo(types, this._anyOfTypes);
+    public anyOf(
+        type: IType<any> | Array<IType<any>>,
+        ...types: Array<IType<any>>
+    ): TypeMatcher {
+        if (type instanceof Array) {
+            this.pushAddedTypesTo(type.concat(types), this._anyOfTypes);
+        } else {
+            this.pushAddedTypesTo([type].concat(types), this._anyOfTypes);
+        }
         return this;
     }
 
     /**
      * Types that an item must not extend or implement
      */
-    public noneOf(...types: any[]): TypeMatcher {
-        this.pushAddedTypesTo(types, this._noneOfTypes);
+    public noneOf(
+        type: IType<any> | Array<IType<any>>,
+        ...types: Array<IType<any>>
+    ): TypeMatcher {
+        if (type instanceof Array) {
+            this.pushAddedTypesTo(type.concat(types), this._noneOfTypes);
+        } else {
+            this.pushAddedTypesTo([type].concat(types), this._noneOfTypes);
+        }
         return this;
     }
 
@@ -103,7 +124,7 @@ export class TypeMatcher implements ITypeMatcher, ITypeMatcherFactory {
     }
 
     protected pushAddedTypesTo(
-        types: any[],
+        types: Array<IType<any>>,
         targetSet: Array<IType<any>>
     ): void {
         if (this._typeFilter) {
@@ -118,15 +139,10 @@ export class TypeMatcher implements ITypeMatcher, ITypeMatcherFactory {
     }
 
     protected pushValuesToTargetSet(
-        values: any[],
+        values: Array<IType<any>>,
         targetSet: Array<IType<any>>
     ): void {
-        let types: Array<IType<any>> =
-            values.length === 1 && values[0] instanceof Array
-                ? values[0]
-                : values;
-
-        types.forEach(type => {
+        values.forEach((type: IType<any>) => {
             targetSet.push(type);
         });
     }

--- a/test/robotlegs/bender/extensions/matching/typeMatcher.test.ts
+++ b/test/robotlegs/bender/extensions/matching/typeMatcher.test.ts
@@ -23,7 +23,7 @@ describe("TypeMatcher", () => {
     const ALL_OF_2: Array<IType<any>> = [Object];
     const ANY_OF: Array<IType<any>> = [Boolean, Number];
     const ANY_OF_2: Array<IType<any>> = [Array, Date];
-    const NONE_OF: Array<IType<any>> = [Error];
+    const NONE_OF: Array<IType<any>> = [Error, TypeError];
     const NONE_OF_2: Array<IType<any>> = [TypeMatcherError];
 
     let matcher: TypeMatcher;
@@ -238,7 +238,21 @@ describe("TypeMatcher", () => {
         matcher
             .allOf(BaseType, ExtendedType)
             .anyOf(Boolean, Number)
-            .noneOf(Error);
+            .noneOf(Error, TypeError);
+        assertMatchesTypeFilter(matcher.createTypeFilter(), expectedFilter);
+    });
+
+    it("mixing_all_any_and_none_arguments_also_works", () => {
+        const expectedFilter: TypeFilter = new TypeFilter(
+            ALL_OF,
+            ANY_OF,
+            NONE_OF
+        );
+        matcher = new TypeMatcher();
+        matcher
+            .allOf([BaseType], ExtendedType)
+            .anyOf([Boolean], Number)
+            .noneOf([Error], TypeError);
         assertMatchesTypeFilter(matcher.createTypeFilter(), expectedFilter);
     });
 


### PR DESCRIPTION
The methods **allOf**, **anyOf** and **noneOf** of **TypeMatcher** are now checking properly the type of all parameters.

Each parameter passed through one of these methods have to be an instance of **IClass<any>**, that means, a reference for a **class**.

This change should not break previous implementations since is only adopting a more strict type checking approach.